### PR TITLE
Reuse authentication state

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -79,4 +79,11 @@ jobs:
       uses: GabrielBB/xvfb-action@v1
       with:
         working-directory: ./ #optional
-        run: robot -v BROWSER:${{ matrix.browser }} -e IgnoreORIgnore_${{ matrix.browser }} Examples
+        run: robot --outputdir test-report -v BROWSER:${{ matrix.browser }} -e IgnoreORIgnore_${{ matrix.browser }} Examples
+    - name: Upload a test report
+      if: always()
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        # Artifact name
+        name: test-report
+        path: test-report

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ Examples/test.csv
 .venv/
 Examples/trace.zip
 Examples/traces/
+Examples/state-admin.json

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ Examples/test.csv
 Examples/trace.zip
 Examples/traces/
 Examples/state-admin.json
+Examples/test-report/
+test-report/

--- a/Examples/browser-management/handle-state.robot
+++ b/Examples/browser-management/handle-state.robot
@@ -1,6 +1,5 @@
 *** Settings ***
 Library    PuppeteerLibrary
-Library    Dialogs    
 Test Setup    Open browser to test page    
 Test Teardown    Close All Browser
 Suite Teardown    Close Puppeteer
@@ -26,13 +25,16 @@ Save and Reuse browser authen state into json file
     Wait Until Page Contains    ${USERNAME}    
     Save Browser Storage State    admin
     Close All Browser
+    ############################################################
     # Reopen and bypass login by using state ref
+    ############################################################
     ${BROWSER} =     Get variable value    ${BROWSER}     ${DEFAULT_BROWSER}
     ${HEADLESS}     Get variable value    ${HEADLESS}    ${False}
     &{options} =    create dictionary   headless=${HEADLESS}    state_ref=admin
     Open browser    ${PROFILE_PAGE_URL}   browser=${BROWSER}    options=${options}
     Wait Until Page Contains    ${USERNAME}
-
+    Delete Browser Storage State    admin
+    Delete All Browser Storage States
 
 *** Keywords ***
 Open browser to test page

--- a/Examples/browser-management/handle-state.robot
+++ b/Examples/browser-management/handle-state.robot
@@ -18,9 +18,7 @@ Save and Reuse browser authen state into json file
     [Tags]    Ignore_ptchrome
     Input Text    id=userName    ${USERNAME}
     Input Password    id=password    ${PASSWORD}
-    Run Async Keywords    
-    ...    Wait For Navigation    AND
-    ...    Click Element    id=login
+    Click Element    id=login
     Wait Until Page Contains Element    id=userName-value
     Wait Until Page Contains    ${USERNAME}    
     Save Browser Storage State    admin
@@ -42,3 +40,5 @@ Open browser to test page
     ${HEADLESS}     Get variable value    ${HEADLESS}    ${False}
     &{options} =    create dictionary   headless=${HEADLESS}
     Open browser    ${HOME_PAGE_URL}   browser=${BROWSER}    options=${options}
+    Set Screenshot Directory    test-report
+    Capture Page Screenshot        

--- a/Examples/browser-management/handle-state.robot
+++ b/Examples/browser-management/handle-state.robot
@@ -1,0 +1,42 @@
+*** Settings ***
+Library    PuppeteerLibrary
+Library    Dialogs    
+Test Setup    Open browser to test page    
+Test Teardown    Close All Browser
+Suite Teardown    Close Puppeteer
+
+
+*** Variables ***
+${DEFAULT_BROWSER}    chrome
+${HOME_PAGE_URL}    https://demoqa.com/login
+${PROFILE_PAGE_URL}    https://demoqa.com/profile
+${USERNAME}    qahive
+${PASSWORD}    Welcome1!
+
+
+*** Test Cases ***
+Save and Reuse browser authen state into json file
+    [Tags]    Ignore_ptchrome
+    Input Text    id=userName    ${USERNAME}
+    Input Password    id=password    ${PASSWORD}
+    Run Async Keywords    
+    ...    Wait For Navigation    AND
+    ...    Click Element    id=login
+    Wait Until Page Contains Element    id=userName-value
+    Wait Until Page Contains    ${USERNAME}    
+    Save Browser Storage State    admin
+    Close All Browser
+    # Reopen and bypass login by using state ref
+    ${BROWSER} =     Get variable value    ${BROWSER}     ${DEFAULT_BROWSER}
+    ${HEADLESS}     Get variable value    ${HEADLESS}    ${False}
+    &{options} =    create dictionary   headless=${HEADLESS}    state_ref=admin
+    Open browser    ${PROFILE_PAGE_URL}   browser=${BROWSER}    options=${options}
+    Wait Until Page Contains    ${USERNAME}
+
+
+*** Keywords ***
+Open browser to test page
+    ${BROWSER} =     Get variable value    ${BROWSER}     ${DEFAULT_BROWSER}
+    ${HEADLESS}     Get variable value    ${HEADLESS}    ${False}
+    &{options} =    create dictionary   headless=${HEADLESS}
+    Open browser    ${HOME_PAGE_URL}   browser=${BROWSER}    options=${options}

--- a/PuppeteerLibrary/ikeywords/ibrowsermanagement_async.py
+++ b/PuppeteerLibrary/ikeywords/ibrowsermanagement_async.py
@@ -75,5 +75,5 @@ class iBrowserManagementAsync(BaseAsyncKeywords, ABC):
     ##############################
     # State
     ##############################
-    async def save_browser_storage_state(self, ref='user'):
+    async def save_browser_storage_state(self, state_folder: str, ref='user'):
         pass

--- a/PuppeteerLibrary/ikeywords/ibrowsermanagement_async.py
+++ b/PuppeteerLibrary/ikeywords/ibrowsermanagement_async.py
@@ -71,3 +71,9 @@ class iBrowserManagementAsync(BaseAsyncKeywords, ABC):
 
     async def delete_all_cookies(self):
         pass
+    
+    ##############################
+    # State
+    ##############################
+    async def save_browser_storage_state(self, ref='user'):
+        pass

--- a/PuppeteerLibrary/keywords/browsermanagement.py
+++ b/PuppeteerLibrary/keywords/browsermanagement.py
@@ -1,3 +1,5 @@
+import os
+import shutil
 from PuppeteerLibrary.base.librarycomponent import LibraryComponent
 from PuppeteerLibrary.base.robotlibcore import keyword
 from PuppeteerLibrary.ikeywords.ibrowsermanagement_async import iBrowserManagementAsync
@@ -8,6 +10,7 @@ class BrowserManagementKeywords(LibraryComponent):
 
     def __init__(self, ctx):
         super().__init__(ctx)
+        self.STATES_FOLDER = './states'
 
     def get_async_keyword_group(self) -> iBrowserManagementAsync:
         return self.ctx.get_current_library_context().get_async_keyword_group(type(self).__name__)
@@ -241,11 +244,41 @@ class BrowserManagementKeywords(LibraryComponent):
     ##############################
     @keyword
     def save_browser_storage_state(self, ref='user'):
-        """ Save browser storate state that can resue Authentication state
+        """ Save browser storage state that can resue Authentication state
 
             *ref* : reference state name
 
             *Limitation* only support Playwright browser
         """
         self.info('Save storate state for ' + ref)
-        return self.loop.run_until_complete(self.get_async_keyword_group().save_browser_storage_state(ref))
+        try:
+            os.mkdir(self.STATES_FOLDER)
+        except:
+            self.info('states folder already exists.')
+        return self.loop.run_until_complete(self.get_async_keyword_group().save_browser_storage_state(self.STATES_FOLDER, ref))
+
+    @keyword
+    def delete_browser_storage_state(self, ref):
+        """ Delete browser storage state
+
+            *ref* : reference state name
+
+            *Limitation* only support Playwright browser
+        """
+        file_path = self.STATES_FOLDER +'/state-'+ ref + '.json'
+        if os.path.exists(file_path):
+            os.remove(file_path)
+        else:
+            self.warn('Can not delete the storate '+ref+' as it doesn\'t exists')
+
+    @keyword
+    def delete_all_browser_storage_states(self):
+        """ Delete all browser storage state
+
+            *Limitation* only support Playwright browser
+        """
+        try:
+            shutil.rmtree(self.STATES_FOLDER)
+        except OSError as e:
+            self.warn("Error: %s - %s." % (e.filename, e.strerror))
+

--- a/PuppeteerLibrary/keywords/browsermanagement.py
+++ b/PuppeteerLibrary/keywords/browsermanagement.py
@@ -32,6 +32,7 @@ class BrowserManagementKeywords(LibraryComponent):
         | width              | default 1366           |
         | height             | default 768            |
         | emulate            | iPhone 11              |
+        | state_ref          | State Reference        |
 
         **Other options**
         pwchrome, webkit and firefox please visit: https://playwright.dev/python/docs/api/class-browser?_highlight=new_page#browsernew_pagekwargs
@@ -234,3 +235,17 @@ class BrowserManagementKeywords(LibraryComponent):
         """ Deletes all cookies.
         """
         return self.loop.run_until_complete(self.get_async_keyword_group().delete_all_cookies())
+
+    ##############################
+    # State
+    ##############################
+    @keyword
+    def save_browser_storage_state(self, ref='user'):
+        """ Save browser storate state that can resue Authentication state
+
+            *ref* : reference state name
+
+            *Limitation* only support Playwright browser
+        """
+        self.info('Save storate state for ' + ref)
+        return self.loop.run_until_complete(self.get_async_keyword_group().save_browser_storage_state(ref))

--- a/PuppeteerLibrary/playwright/async_keywords/playwright_browsermanagement.py
+++ b/PuppeteerLibrary/playwright/async_keywords/playwright_browsermanagement.py
@@ -137,3 +137,10 @@ class PlaywrightBrowserManagement(iBrowserManagementAsync):
 
     async def delete_all_cookies(self):
         await self.library_ctx.get_browser_context().contexts[0].clear_cookies()
+
+    ##############################
+    # State
+    ##############################
+    async def save_browser_storage_state(self, ref='user'):
+        storage  = await self.library_ctx.get_browser_context().contexts[0].storage_state(path="state-"+ ref +".json")
+        return storage

--- a/PuppeteerLibrary/playwright/async_keywords/playwright_browsermanagement.py
+++ b/PuppeteerLibrary/playwright/async_keywords/playwright_browsermanagement.py
@@ -141,6 +141,6 @@ class PlaywrightBrowserManagement(iBrowserManagementAsync):
     ##############################
     # State
     ##############################
-    async def save_browser_storage_state(self, ref='user'):
-        storage  = await self.library_ctx.get_browser_context().contexts[0].storage_state(path="state-"+ ref +".json")
+    async def save_browser_storage_state(self, state_folder, ref='user'):
+        storage  = await self.library_ctx.get_browser_context().contexts[0].storage_state(path=state_folder+"/state-"+ ref +".json")
         return storage

--- a/PuppeteerLibrary/playwright/playwright_context.py
+++ b/PuppeteerLibrary/playwright/playwright_context.py
@@ -113,6 +113,9 @@ class PlaywrightContext(iLibraryContext):
         if 'emulate' in options:
             device_options = self.playwright.devices[options['emulate']]
 
+        if 'state_ref' in options:
+            device_options['storage_state'] = 'state-'+ options['state_ref'] + '.json'
+
         new_page = await self.browser.new_page(**device_options)
         self.current_page = PlaywrightPage(new_page)
         return self.current_page

--- a/PuppeteerLibrary/playwright/playwright_context.py
+++ b/PuppeteerLibrary/playwright/playwright_context.py
@@ -114,7 +114,7 @@ class PlaywrightContext(iLibraryContext):
             device_options = self.playwright.devices[options['emulate']]
 
         if 'state_ref' in options:
-            device_options['storage_state'] = 'state-'+ options['state_ref'] + '.json'
+            device_options['storage_state'] = './states/state-'+ options['state_ref'] + '.json'
 
         new_page = await self.browser.new_page(**device_options)
         self.current_page = PlaywrightPage(new_page)

--- a/PuppeteerLibrary/puppeteer/async_keywords/puppeteer_browsermanagement.py
+++ b/PuppeteerLibrary/puppeteer/async_keywords/puppeteer_browsermanagement.py
@@ -148,5 +148,5 @@ class PuppeteerBrowserManagement(iBrowserManagementAsync):
     ##############################
     # State
     ##############################
-    async def save_browser_storage_state(self, ref='user'):
+    async def save_browser_storage_state(self, state_folder, ref='user'):
         raise Exception('Not support for puppeteer browser')

--- a/PuppeteerLibrary/puppeteer/async_keywords/puppeteer_browsermanagement.py
+++ b/PuppeteerLibrary/puppeteer/async_keywords/puppeteer_browsermanagement.py
@@ -144,3 +144,9 @@ class PuppeteerBrowserManagement(iBrowserManagementAsync):
         cookies = await self.library_ctx.get_current_page().get_page().cookies()
         for cookie in cookies:
             await self.library_ctx.get_current_page().get_page().deleteCookie(cookie)
+
+    ##############################
+    # State
+    ##############################
+    async def save_browser_storage_state(self, ref='user'):
+        raise Exception('Not support for puppeteer browser')


### PR DESCRIPTION
Support reuse playwright browser state by following new keywords 
- **Save Browser Storage State**
- **Delete Browser Storage State**
- **Delete All Browser Storage States**
- **Open browser** support state_ref option
